### PR TITLE
Get Rspec Passing

### DIFF
--- a/lib/mini_mediainfo.rb
+++ b/lib/mini_mediainfo.rb
@@ -5,7 +5,7 @@ require 'open3'
 module MiniMediainfo
 
   def self.platform_supported?
-    /(darwin|linux|unix)/ =~ RUBY_PLATFORM
+    %w{darwin linux unix}.any?{|os_string| RUBY_PLATFORM.include?(os_string) }
   end
 
   def self.mediainfo_version

--- a/lib/mini_mediainfo/version.rb
+++ b/lib/mini_mediainfo/version.rb
@@ -1,3 +1,3 @@
 module MiniMediainfo
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end

--- a/mini_mediainfo.gemspec
+++ b/mini_mediainfo.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rspec", "3.5.0"
   spec.add_development_dependency "thin"
   spec.add_development_dependency "sinatra"
 end

--- a/spec/media_spec.rb
+++ b/spec/media_spec.rb
@@ -41,10 +41,10 @@ describe MiniMediainfo::Media do
   end
 
   def should_have_proper_data(meta_data)
-    meta_data.is_a?(Hash).should be_true
+    meta_data.is_a?(Hash).should be true
 
     ['General', 'Audio', 'Video'].each do |k|
-      meta_data.has_key?(k).should be_true
+      meta_data.has_key?(k).should be true
       meta_data[k].size.should > 0
     end
     # test format for a couple of key properties

--- a/spec/mini_mediainfo_spec.rb
+++ b/spec/mini_mediainfo_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe MiniMediainfo do
 
   it "should determine if the platform is supported" do
-    subject.respond_to?(:platform_supported?).should be_true
-    subject.platform_supported?.should be_true
+    subject.respond_to?(:platform_supported?).should be true
+    subject.platform_supported?.should be true
   end
 
   it "should get mediainfo version" do


### PR DESCRIPTION
Hey @kforsman.

Firstly - this is a good library! 
Thanks for putting it together - it's clearly a labor of love.
This Pull Request...
#### Changes `be_true` assertions to `be true`

The `be_foo` rspec magic ends up calling `foo?` on the object so the existing specs are
calling `.true?` when they _should_ be asserting truth.
##### Changes what `platform_supported?` returns

The existing code returns an int, the position where "darwin", "linux", or "unix" appears in 
`RUBY_PLATFORM`. This will return a bool, which is what it looks like the rspecs wanted.
#### Finally
- Lock Rspec down to 3.5.0
- Version bump! 🚀 
