### PR TITLE
Migrate from should() syntax to new, expect() syntax

### DIFF
--- a/spec/media_spec.rb
+++ b/spec/media_spec.rb
@@ -4,14 +4,13 @@ require 'rspec'
 require "mini_mediainfo/media"
 require "net/http"
 
-
 describe MiniMediainfo::Media do
 
   context "when introspecting files" do
 
     it "should introspect audio file" do
       media = MiniMediainfo::Media.new("spec/support/small.mp4")
-      media.should_not be_nil
+      expect(media).to_not be_nil
       media.introspect
       should_have_proper_data(media.meta)
     end
@@ -31,32 +30,33 @@ describe MiniMediainfo::Media do
 
     it "should introspect video url" do
       res = Net::HTTP.start('localhost', 4567) { |http| http.get('/small.mp4') }
-      res.code.should == '200'
+      expect(res.code).to eq('200')
 
       media = MiniMediainfo::Media.new("http://localhost:4567/small.mp4")
-      media.should_not be_nil
+      expect(media).to_not be_nil
       media.introspect
       should_have_proper_data(media.meta)
     end
   end
 
   def should_have_proper_data(meta_data)
-    meta_data.is_a?(Hash).should be true
+    expect(meta_data).to be_a(Hash)
 
     ['General', 'Audio', 'Video'].each do |k|
-      meta_data.has_key?(k).should be true
-      meta_data[k].size.should > 0
+      expect(meta_data).to have_key(k)
+      expect(meta_data[k]).to_not be_empty
     end
     # test format for a couple of key properties
     number_format = /^[\d]+(\.[\d]+){0,1}$/
-    meta_data['General']['Duration'].should match(number_format) #ms
-    meta_data['Video']['Codec ID'].should_not be_nil # avc1
-    meta_data['Video']['Frame rate'].should match(number_format) # (fps)
-    meta_data['Video']['Width'].should match(number_format) # 1280
-    meta_data['Video']['Height'].should match(number_format) # 1280
-    meta_data['Video']['Format profile'].should_not be_nil # Main@L3.2
-    meta_data['Video']['Bit rate'].should match(number_format) # 1280
-    meta_data['Audio']['Bit rate'].should match(number_format) # 1280
-    meta_data['Audio']['Codec'].should_not be_nil # AAC
+
+    expect(meta_data['General']['Duration']).to match(number_format) #ms
+    expect(meta_data['Video']['Codec ID']).to_not be_nil # avc1
+    expect(meta_data['Video']['Frame rate']).to match(number_format) # (fps)
+    expect(meta_data['Video']['Width']).to match(number_format) # 1280
+    expect(meta_data['Video']['Height']).to match(number_format) # 1280
+    expect(meta_data['Video']['Format profile']).to_not be_nil # Main@L3.2
+    expect(meta_data['Video']['Bit rate']).to match(number_format) # 1280
+    expect(meta_data['Audio']['Bit rate']).to match(number_format) # 1280
+    expect(meta_data['Audio']['Codec']).to_not be_nil # AAC
   end
 end

--- a/spec/mini_mediainfo_spec.rb
+++ b/spec/mini_mediainfo_spec.rb
@@ -3,18 +3,17 @@ require 'spec_helper'
 describe MiniMediainfo do
 
   it "should determine if the platform is supported" do
-    subject.respond_to?(:platform_supported?).should be true
-    subject.platform_supported?.should be true
+    expect(subject.platform_supported?).to eq(true)
   end
 
   it "should get mediainfo version" do
     version = subject.mediainfo_version
-    version.should_not be_nil
-    version.should match(/MediaInfoLib - v/)
+    expect(version).to_not be_nil
+    expect(version).to match(/MediaInfoLib - v/)
   end
 
   it "should tell which mediainfo binary" do
-    subject.mediainfo_binary.should match /\/mediainfo/
+    expect(subject.mediainfo_binary).to match /\/mediainfo/
   end
 
 end


### PR DESCRIPTION
Hey @kforsman 

Sorry to send another PR one hot on the heels of your so graciously accepting the first one.
Now that you're locking in rspec to 3.5.0...the `.should()` syntax has been deprecated in favor of `expect()`.

So:

```ruby
foo.should eq(bar)
foo.should_not eq(bar)

# becomes
expect(foo).to eq(bar)
expect(foo).not_to eq(bar)
```

http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/

I didn't bump the version number since this wouldn't change any runtime behavior since 0.0.4.